### PR TITLE
サイマルキャストに対応

### DIFF
--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -48,6 +48,9 @@ public class SoraSample : MonoBehaviour
     public string audioRecordingDevice = "";
     public string audioPlayoutDevice = "";
 
+    public bool spotlight = false;
+    public bool simulcast = false;
+
     public bool Recvonly { get { return fixedSampleType == SampleType.Recvonly || fixedSampleType == SampleType.MultiRecvonly; } }
     public bool MultiRecv { get { return fixedSampleType == SampleType.MultiRecvonly || fixedSampleType == SampleType.MultiSendrecv; } }
     public bool Multistream { get { return fixedSampleType == SampleType.MultiSendonly || fixedSampleType == SampleType.MultiRecvonly || fixedSampleType == SampleType.MultiSendrecv; } }
@@ -350,6 +353,8 @@ public class SoraSample : MonoBehaviour
             VideoCapturerDevice = videoCapturerDevice,
             AudioRecordingDevice = audioRecordingDevice,
             AudioPlayoutDevice = audioPlayoutDevice,
+            Spotlight = spotlight,
+            Simulcast = simulcast,
         };
         if (captureUnityCamera && capturedCamera != null)
         {

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -49,6 +49,7 @@ public class SoraSample : MonoBehaviour
     public string audioPlayoutDevice = "";
 
     public bool spotlight = false;
+    public int spotlightNumber = 0;
     public bool simulcast = false;
 
     public int videoBitrate = 0;
@@ -395,6 +396,7 @@ public class SoraSample : MonoBehaviour
             AudioRecordingDevice = audioRecordingDevice,
             AudioPlayoutDevice = audioPlayoutDevice,
             Spotlight = spotlight,
+            SpotlightNumber = spotlightNumber,
             Simulcast = simulcast,
         };
         if (captureUnityCamera && capturedCamera != null)

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -51,6 +51,17 @@ public class SoraSample : MonoBehaviour
     public bool spotlight = false;
     public bool simulcast = false;
 
+    public int videoBitrate = 0;
+    public enum VideoSize
+    {
+        QVGA,
+        VGA,
+        HD,
+        FHD,
+        _4K,
+    }
+    public VideoSize videoSize = VideoSize.VGA;
+
     public bool Recvonly { get { return fixedSampleType == SampleType.Recvonly || fixedSampleType == SampleType.MultiRecvonly; } }
     public bool MultiRecv { get { return fixedSampleType == SampleType.MultiRecvonly || fixedSampleType == SampleType.MultiSendrecv; } }
     public bool Multistream { get { return fixedSampleType == SampleType.MultiSendonly || fixedSampleType == SampleType.MultiRecvonly || fixedSampleType == SampleType.MultiSendrecv; } }
@@ -340,6 +351,33 @@ public class SoraSample : MonoBehaviour
 
         InitSora();
 
+        int videoWidth = 640;
+        int videoHeight = 480;
+
+        switch (videoSize)
+        {
+            case VideoSize.QVGA:
+                videoWidth = 320;
+                videoHeight = 240;
+                break;
+            case VideoSize.VGA:
+                videoWidth = 640;
+                videoHeight = 480;
+                break;
+            case VideoSize.HD:
+                videoWidth = 1280;
+                videoHeight = 720;
+                break;
+            case VideoSize.FHD:
+                videoWidth = 1920;
+                videoHeight = 1080;
+                break;
+            case VideoSize._4K:
+                videoWidth = 3840;
+                videoHeight = 2160;
+                break;
+        }
+
         var config = new Sora.Config()
         {
             SignalingUrl = signalingUrl,
@@ -348,6 +386,9 @@ public class SoraSample : MonoBehaviour
             Role = Role,
             Multistream = Multistream,
             VideoCodec = videoCodec,
+            VideoBitrate = videoBitrate,
+            VideoWidth = videoWidth,
+            VideoHeight = videoHeight,
             UnityAudioInput = unityAudioInput,
             UnityAudioOutput = unityAudioOutput,
             VideoCapturerDevice = videoCapturerDevice,

--- a/copy.sh
+++ b/copy.sh
@@ -7,16 +7,16 @@ cp -r ../sora-unity-sdk/Sora/Editor/ SoraUnitySdkSamples/Assets/SoraUnitySdk/Edi
 if [ "$1" = "macos" ]; then
   mkdir -p SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/macos
   rm -rf SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/macos/SoraUnitySdk.bundle
-  cp -r ../sora-unity-sdk/build/SoraUnitySdk.bundle SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/macos/
+  cp -r ../sora-unity-sdk/_build/sora-unity-sdk/macos/SoraUnitySdk.bundle SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/macos/
 elif [ "$1" = "ios" ]; then
   mkdir -p SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios
   rm -rf SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/libSoraUnitySdk.a
-  cp -r ../sora-unity-sdk/build/ios/_install/lib/libSoraUnitySdk.a SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/
+  cp -r ../sora-unity-sdk/_build/sora-unity-sdk/ios/libSoraUnitySdk.a SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/
   cp -r ../sora-unity-sdk/_install/ios/webrtc/lib/libwebrtc.a SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/
 elif [ "$1" = "android" ]; then
   mkdir -p SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/android/arm64-v8a/
   rm -f SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/android/arm64-v8a/libSoraUnitySdk.so
-  cp ../sora-unity-sdk/build/android/libSoraUnitySdk.so SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/android/arm64-v8a/
+  cp ../sora-unity-sdk/_build/sora-unity-sdk/android/libSoraUnitySdk.so SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/android/arm64-v8a/
   cp ../sora-unity-sdk/_install/android/webrtc/jar/webrtc.jar SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/android/
 else
   echo "$0 <macos|ios|android>"

--- a/install.ps1
+++ b/install.ps1
@@ -3,7 +3,7 @@
 $ErrorActionPreference = 'Stop'
 
 
-$SORAUNITYSDK_VERSION = "2020.10"
+$SORAUNITYSDK_VERSION = "2020.1"
 
 # 一通り掃除
 if (Test-Path "SoraUnitySdk.zip") {

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -ex
 
 # SoraUnitySdk をダウンロードして SoraUnitySdkSamples にインストールする
 
-SORAUNITYSDK_VERSION="2020.10"
+SORAUNITYSDK_VERSION="2021.1"
 
 # 掃除
 rm -f SoraUnitySdk.zip


### PR DESCRIPTION
3本以上のストリームを流すには、HD 以上のサイズで、ビットレートをある程度高い値（1500 以上）にしてください。

こちらでは、Windows, macOS, iOS, Android で、カメラから取り込んだ映像を、sendonly+シングルストリーム+サイマルキャスト+(VP8 or H264) で送信して、ブラウザから正しく受信できたのを確認しました。
それ以外は未確認です。

あとついでにスポットライトにも対応しました。が、多分動作するだろうということで特に確認していません。