### PR TITLE
Feature/fix install script

### DIFF
--- a/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/libboost_json.a.meta
+++ b/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/libboost_json.a.meta
@@ -67,7 +67,7 @@ PluginImporter:
         AddToEmbeddedBinaries: false
         CPU: AnyCPU
         CompileFlags: 
-        FrameworkDependencies: 
+        FrameworkDependencies: OpenGLES;
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/libboost_json.a.meta
+++ b/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/libboost_json.a.meta
@@ -1,0 +1,73 @@
+fileFormatVersion: 2
+guid: 82cf273bcbfad410e95fff95a3d37d87
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 0
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/install.ps1
+++ b/install.ps1
@@ -41,6 +41,7 @@ Push-Location SoraUnitySdk
     Copy-File Plugins\SoraUnitySdk\android\arm64-v8a\libSoraUnitySdk.so $_dstbase
     Copy-File Plugins\SoraUnitySdk\ios\libwebrtc.a $_dstbase
     Copy-File Plugins\SoraUnitySdk\ios\libSoraUnitySdk.a $_dstbase
+    Copy-File Plugins\SoraUnitySdk\ios\libboost_json.a $_dstbase
     Copy-File Plugins\SoraUnitySdk\windows\x86_64\SoraUnitySdk.dll $_dstbase
     New-Item $_dstbase\Plugins\SoraUnitySdk\macos -ItemType Directory -ErrorAction SilentlyContinue
     if (Test-Path "$_dstbase\Plugins\SoraUnitySdk\macos\SoraUnitySdk.bundle") {

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,7 @@ pushd SoraUnitySdk
   copy_file Plugins/SoraUnitySdk/android/arm64-v8a/libSoraUnitySdk.so $_dstbase
   copy_file Plugins/SoraUnitySdk/ios/libwebrtc.a $_dstbase
   copy_file Plugins/SoraUnitySdk/ios/libSoraUnitySdk.a $_dstbase
+  copy_file Plugins/SoraUnitySdk/ios/libboost_json.a $_dstbase
   copy_file Plugins/SoraUnitySdk/windows/x86_64/SoraUnitySdk.dll $_dstbase
   mkdir -p $_dstbase/Plugins/SoraUnitySdk/macos/
   rm -rf $_dstbase/Plugins/SoraUnitySdk/macos/SoraUnitySdk.bundle/


### PR DESCRIPTION
- install.sh と install.ps1 に libboost_json.a をコピーする処理を追加しました
   Sora Unity SDK の Release 2022.1.0 にて追加された iOS 用のプラグイン libboost_json.a をサンプル集のセットアップ時に使用する install.sh と install.ps1 にコピーする処理がなかったため追加しました。 

- libboost_json.a.meta を追加しました
   libboost_json.a はセットアップ時に Unity Editor でビルド用の設定をする必要がありますが、都度設定するのは大変なのでmeta ファイルを追加し、設定を省略できるようにしました