### PR TITLE
signalingkey を汎用的な metadata に置き換える

### DIFF
--- a/SoraUnitySdkSamples/Assets/Scenes/multi_recvonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_recvonly.unity
@@ -388,7 +388,7 @@ MonoBehaviour:
   baseContent: {fileID: 1255258845}
   signalingUrl: 
   channelId: 
-  signalingKey: 
+  metadata: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 0}
   videoCodecType: 0

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_sendonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_sendonly.unity
@@ -1494,7 +1494,7 @@ MonoBehaviour:
   baseContent: {fileID: 0}
   signalingUrl: 
   channelId: 
-  signalingKey: 
+  metadata: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 763227567}
   videoCodecType: 0

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_sendrecv.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_sendrecv.unity
@@ -2185,7 +2185,7 @@ MonoBehaviour:
   channelId: 
   clientId: 
   bundleId: 
-  signalingKey: 
+  metadata: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 759273323}
   video: 1

--- a/SoraUnitySdkSamples/Assets/Scenes/recvonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/recvonly.unity
@@ -1070,7 +1070,7 @@ MonoBehaviour:
   baseContent: {fileID: 0}
   signalingUrl: 
   channelId: 
-  signalingKey: 
+  metadata: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 0}
   videoCodecType: 0

--- a/SoraUnitySdkSamples/Assets/Scenes/sendonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/sendonly.unity
@@ -533,7 +533,7 @@ MonoBehaviour:
   baseContent: {fileID: 0}
   signalingUrl: 
   channelId: 
-  signalingKey: 
+  metadata: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 1285571995}
   videoCodecType: 0

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -39,7 +39,7 @@ public class SoraSample : MonoBehaviour
     public string channelId = "";
     public string clientId = "";
     public string bundleId = "";
-    public string signalingKey = "";
+    public string metadata = "";
 
     public bool captureUnityCamera;
     public Camera capturedCamera;
@@ -390,13 +390,7 @@ public class SoraSample : MonoBehaviour
         public string signaling_url = "";
         public string[] signaling_url_candidate = new string[0];
         public string channel_id = "";
-        public string signaling_key = "";
-    }
-
-    [Serializable]
-    class Metadata
-    {
-        public string signaling_key;
+        public string metadata = "";
     }
 
     public void OnClickStart()
@@ -409,7 +403,7 @@ public class SoraSample : MonoBehaviour
             signalingUrl = settings.signaling_url;
             signalingUrlCandidate = settings.signaling_url_candidate;
             channelId = settings.channel_id;
-            signalingKey = settings.signaling_key;
+            metadata = settings.metadata;
         }
 
         if (signalingUrl.Length == 0 && signalingUrlCandidate.Length == 0)
@@ -421,16 +415,6 @@ public class SoraSample : MonoBehaviour
         {
             Debug.LogError("チャンネル ID が設定されていません");
             return;
-        }
-        // signalingKey がある場合はメタデータを設定する
-        string metadata = "";
-        if (signalingKey.Length != 0)
-        {
-            var md = new Metadata()
-            {
-                signaling_key = signalingKey
-            };
-            metadata = JsonUtility.ToJson(md);
         }
 
         InitSora();


### PR DESCRIPTION
現在の Unity SDK サンプルは Sora Labo への接続設定が簡易にできるように Signaling Key が設定できるようになっていますが、
これを metadata に変更したいです。

Sora Labo に送信する metadata は `{"signaling_key": "<シグナリングキー>"}` ですが、
Tobi に送信する metadata は `{"tobi_access_token": "<トークン>"}` であるためです。

Sora Labo を使っていた方は今後 `<シグナリングキー>` ではなく  `{"signaling_key": "<シグナリングキー>"}` を設定いただくことになります。

入力された metadata の形式チェックは入れていません。
Sora 側のチェックでエラーになります。

[![Image from Gyazo](https://i.gyazo.com/fdc69648abd944f4155c180c48a7e7a1.png)](https://gyazo.com/fdc69648abd944f4155c180c48a7e7a1)