### PR TITLE
iOS の Build Target の最小バージョンを修正

### DIFF
--- a/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/libsora.a.meta
+++ b/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/ios/libsora.a.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 21eebe337986d4d35a2def7b3358803a
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SoraUnitySdkSamples/ProjectSettings/ProjectSettings.asset
+++ b/SoraUnitySdkSamples/ProjectSettings/ProjectSettings.asset
@@ -179,7 +179,7 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 9.0
+  iOSTargetOSVersionString: 12.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 9.0


### PR DESCRIPTION
- iOS の最小バージョンを 12.0 に修正しました
- 削除してしまった meta ファイルをもうラインナップに再度追加しました