### PR TITLE
metadata の key に tobi_access_token を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
     - @melpon
 - [ADD] BundleId の設定を追加
     - @melpon
+- [ADD] tobiAccessToken の設定を追加
+    - @miosakuma
 
 ## sora-unity-sdk-2022.1.0-1
 

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_recvonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_recvonly.unity
@@ -388,6 +388,7 @@ MonoBehaviour:
   baseContent: {fileID: 1255258845}
   signalingUrl: 
   channelId: 
+  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 0}

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_sendonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_sendonly.unity
@@ -1494,6 +1494,7 @@ MonoBehaviour:
   baseContent: {fileID: 0}
   signalingUrl: 
   channelId: 
+  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 763227567}

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_sendrecv.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_sendrecv.unity
@@ -2185,6 +2185,7 @@ MonoBehaviour:
   channelId: 
   clientId: 
   bundleId: 
+  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 759273323}

--- a/SoraUnitySdkSamples/Assets/Scenes/recvonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/recvonly.unity
@@ -1070,6 +1070,7 @@ MonoBehaviour:
   baseContent: {fileID: 0}
   signalingUrl: 
   channelId: 
+  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 0}

--- a/SoraUnitySdkSamples/Assets/Scenes/sendonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/sendonly.unity
@@ -533,6 +533,7 @@ MonoBehaviour:
   baseContent: {fileID: 0}
   signalingUrl: 
   channelId: 
+  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 1285571995}

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -39,6 +39,7 @@ public class SoraSample : MonoBehaviour
     public string channelId = "";
     public string clientId = "";
     public string bundleId = "";
+    public string tobiAccessToken = "";
     public string signalingKey = "";
 
     public bool captureUnityCamera;
@@ -390,12 +391,14 @@ public class SoraSample : MonoBehaviour
         public string signaling_url = "";
         public string[] signaling_url_candidate = new string[0];
         public string channel_id = "";
+        public string tobi_access_token = "";
         public string signaling_key = "";
     }
 
     [Serializable]
     class Metadata
     {
+        public string tobi_access_token;
         public string signaling_key;
     }
 
@@ -409,6 +412,7 @@ public class SoraSample : MonoBehaviour
             signalingUrl = settings.signaling_url;
             signalingUrlCandidate = settings.signaling_url_candidate;
             channelId = settings.channel_id;
+            tobiAccessToken = settings.tobi_access_token;
             signalingKey = settings.signaling_key;
         }
 
@@ -422,12 +426,13 @@ public class SoraSample : MonoBehaviour
             Debug.LogError("チャンネル ID が設定されていません");
             return;
         }
-        // signalingKey がある場合はメタデータを設定する
+        // signalingKey または tobiAccessToken がある場合はメタデータを設定する
         string metadata = "";
-        if (signalingKey.Length != 0)
+        if (tobiAccessToken.Length != 0 || signalingKey.Length != 0)
         {
             var md = new Metadata()
             {
+                tobi_access_token = tobiAccessToken,
                 signaling_key = signalingKey
             };
             metadata = JsonUtility.ToJson(md);


### PR DESCRIPTION
Tobi に接続するための設定が簡易にできるように metadata に `tobi_access_token`  を追加しました。
インスペクタの `Signaling Key` または `Tobi Access Token` に値が入っていたときに metadata として`signaling_key` と `tobi_access_token` を送るようになっています。

どちらかが空の場合は空文字を送ります。
```
    "metadata": {
      "signaling_key": "",
      "tobi_access_token": "abc"
    },
```