### PR TITLE
Sora Unity SDK 2022.5.1 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@
 
 ## develop
 
-- [UPDATE] Sora Unity SDK 2022.5.0 に上げる
-    - @melpon
+- [UPDATE] Sora Unity SDK 2022.5.1 に上げる
+    - @melpon, @miosakuma
 
 ## sora-unity-sdk-2022.4.0
 

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -69,6 +69,7 @@ public class SoraSample : MonoBehaviour
     public Sora.SimulcastRidType simulcastRidType = Sora.SimulcastRidType.R0;
 
     public int videoBitRate = 0;
+    public int videoFps = 30;
     public enum VideoSize
     {
         QVGA,
@@ -516,6 +517,7 @@ public class SoraSample : MonoBehaviour
             Audio = audio,
             VideoCodecType = videoCodecType,
             VideoBitRate = videoBitRate,
+            VideoFps = videoFps,
             VideoWidth = videoWidth,
             VideoHeight = videoHeight,
             UnityAudioInput = unityAudioInput,

--- a/install.py
+++ b/install.py
@@ -13,7 +13,7 @@ from typing import Callable, Optional, List, Union
 logging.basicConfig(level=logging.DEBUG)
 
 
-SORA_UNITY_SDK_VERSION="2022.5.0"
+SORA_UNITY_SDK_VERSION="2022.5.1"
 
 
 class ChangeDirectory(object):


### PR DESCRIPTION
合わせて今回された Video Fps オプションを追加しています。
画像は 10 に変更してしまっていますがデフォルトは 30 です。
[![Image from Gyazo](https://i.gyazo.com/a54762d57a100122f0c3019527b5eb3c.png)](https://gyazo.com/a54762d57a100122f0c3019527b5eb3c)