### PR TITLE
Sora と接続していないときにボタンを押すとエラーになっていたのを修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [ADD] 音声と映像のミュートを追加
+    - @torikizi
+
 ## sora-unity-sdk-2022.5.2
 
 - [UPDATE] Sora Unity SDK 2022.5.2 に上げる

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -84,8 +84,6 @@ public class SoraSample : MonoBehaviour
     public int dataChannelSignalingTimeout = 30;
     public bool ignoreDisconnectWebsocket = false;
     public int disconnectWaitTimeout = 5;
-    public bool AudioEnabled = false;
-    public bool VideoEnabled = false;
 
     [System.Serializable]
     public class DataChannel
@@ -603,10 +601,18 @@ public class SoraSample : MonoBehaviour
 
     public void OnClickVideoMute()
     {
+        if (sora == null)
+        {
+            return;
+        }
         sora.VideoEnabled = !sora.VideoEnabled; 
     }
     public void OnClickAudioMute()
     {
+        if (sora == null)
+        {
+            return;
+        }
         sora.AudioEnabled = !sora.AudioEnabled; 
     }
 


### PR DESCRIPTION
以下の対応を行いました。
- 不要な定義の削除
- Sora と接続前にミュートボタンを押下してもエラーとしないよう修正
- CHANGES の更新