### PR TITLE
tobiAccessToken の設定を削除

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [CHANGE] tobiAccessToken の設定を削除
+    - @torikizi
 - [ADD] 音声と映像のミュートを追加
     - @torikizi
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In other languages, we won't be able to deal with them. Thank you for your under
 ### 準備するもの
 
 - Unity 開発環境 ([対応 Unity バージョン](#対応-unity-バージョン))
-- サーバー (Sora, Tobi, Sora Labo) への接続情報  ([対応 Sora バージョン](#対応-sora-バージョン))
+- サーバー (Sora, Sora Cloud, Sora Labo) への接続情報  ([対応 Sora バージョン](#対応-sora-バージョン))
 - Python 3
 - (Ubuntu 20.04 x86_64 のみ) libva-drm2 パッケージ (apt インストール)
 
@@ -73,7 +73,6 @@ python3 install.py
 
     - `Signaling Url`: シグナリング URL
     - `Channel Id`: チャネル ID
-    - `Tobi Access Token`: Tobi 向けのアクセストークン
     - `Access Token`: Sora Labo 向けのアクセストークン
 
 4. プレイモードを実行し、ゲームビュー内に表示される「開始」ボタンを押すとサーバーに接続します。

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_recvonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_recvonly.unity
@@ -388,7 +388,6 @@ MonoBehaviour:
   baseContent: {fileID: 1255258845}
   signalingUrl: 
   channelId: 
-  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 0}

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_sendonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_sendonly.unity
@@ -1957,7 +1957,6 @@ MonoBehaviour:
   channelId: 
   clientId: 
   bundleId: 
-  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 763227567}

--- a/SoraUnitySdkSamples/Assets/Scenes/multi_sendrecv.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/multi_sendrecv.unity
@@ -2615,7 +2615,6 @@ MonoBehaviour:
   channelId: 
   clientId: 
   bundleId: 
-  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 759273323}

--- a/SoraUnitySdkSamples/Assets/Scenes/recvonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/recvonly.unity
@@ -1070,7 +1070,6 @@ MonoBehaviour:
   baseContent: {fileID: 0}
   signalingUrl: 
   channelId: 
-  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 0}

--- a/SoraUnitySdkSamples/Assets/Scenes/sendonly.unity
+++ b/SoraUnitySdkSamples/Assets/Scenes/sendonly.unity
@@ -762,7 +762,6 @@ MonoBehaviour:
   channelId: 
   clientId: 
   bundleId: 
-  tobiAccessToken: 
   signalingKey: 
   captureUnityCamera: 0
   capturedCamera: {fileID: 1285571995}

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -39,7 +39,6 @@ public class SoraSample : MonoBehaviour
     public string channelId = "";
     public string clientId = "";
     public string bundleId = "";
-    public string tobiAccessToken = "";
     public string accessToken = "";
 
     public bool captureUnityCamera;
@@ -426,14 +425,12 @@ public class SoraSample : MonoBehaviour
         public string signaling_url = "";
         public string[] signaling_url_candidate = new string[0];
         public string channel_id = "";
-        public string tobi_access_token = "";
         public string access_token = "";
     }
 
     [Serializable]
     class Metadata
     {
-        public string tobi_access_token;
         public string access_token;
     }
 
@@ -447,7 +444,6 @@ public class SoraSample : MonoBehaviour
             signalingUrl = settings.signaling_url;
             signalingUrlCandidate = settings.signaling_url_candidate;
             channelId = settings.channel_id;
-            tobiAccessToken = settings.tobi_access_token;
             accessToken = settings.access_token;
         }
 
@@ -461,13 +457,12 @@ public class SoraSample : MonoBehaviour
             Debug.LogError("チャンネル ID が設定されていません");
             return;
         }
-        // accessToken または tobiAccessToken がある場合はメタデータを設定する
+        // accessToken がある場合はメタデータを設定する
         string metadata = "";
-        if (tobiAccessToken.Length != 0 || accessToken.Length != 0)
+        if (accessToken.Length != 0)
         {
             var md = new Metadata()
             {
-                tobi_access_token = tobiAccessToken,
                 access_token = accessToken
             };
             metadata = JsonUtility.ToJson(md);


### PR DESCRIPTION
tobi のアクセストークンの設定を削除しました。
Sora Labo や Sora Cloud へは  Access Token を使用することで利用可能なことを確認済みです。