### PR TITLE
macOS 向けの Plugins の metadata を修正

### DIFF
--- a/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/macos/arm64/SoraUnitySdk.bundle.meta
+++ b/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/macos/arm64/SoraUnitySdk.bundle.meta
@@ -47,7 +47,7 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: ARM64
+        CPU: AnyCPU
   - first:
       Standalone: Win
     second:


### PR DESCRIPTION
macOS のビルド時、Plugins の対象が AppleSilicon になっていると DLL 読み込みエラー になってしまうのを修正しました。