### PR TITLE
接続中のカメラ切り替え機能に対応

### DIFF
--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -857,7 +857,7 @@ public class SoraSample : MonoBehaviour
             {
                 yield return req.SendWebRequest();
 
-                //if (req.result != UnityEngine.Networking.UnityWebRequest.Result.Success)
+                if (req.result != UnityEngine.Networking.UnityWebRequest.Result.Success)
                 {
                     Debug.LogError("Failed to Get: uri=" + uri + " error=" + req.error);
                     yield break;

--- a/copysdk.py
+++ b/copysdk.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.INFO)
 
 def copy_if_exists(srcfile, dstfile):
     if not os.path.exists(srcfile):
-        logging.info(f'[COPY] Not found: {srcfile}')
+        logging.info(f'Not found: {srcfile}')
         return
     if os.path.isdir(srcfile):
         rm_rf(dstfile)


### PR DESCRIPTION
https://github.com/shiguredo/sora-unity-sdk/pull/76 に対応するサンプルの修正です。
そのままでは切り替え機能は使えませんが、シーンに適当なボタンを用意して `OnClickSwitchCamera`  に紐づければ動作するようになります。