### PR TITLE
iOS のターゲットバージョンを 13.0 にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [CHANGE] プロジェクトを Unity 2022.3 LTS にアップデート
   - @torikizi
+- [UPDATE] iOS の Target Version を 13.0 にアップデート
+  - @torikizi
 
 ## sora-unity-sdk-2023.3.0
 

--- a/SoraUnitySdkSamples/ProjectSettings/ProjectSettings.asset
+++ b/SoraUnitySdkSamples/ProjectSettings/ProjectSettings.asset
@@ -178,7 +178,7 @@ PlayerSettings:
   StripUnusedMeshComponents: 1
   VertexChannelCompressionMask: 4054
   iPhoneSdkVersion: 988
-  iOSTargetOSVersionString: 12.0
+  iOSTargetOSVersionString: 13.0
   tvOSSdkVersion: 0
   tvOSRequireExtendedGameController: 0
   tvOSTargetOSVersionString: 11.0


### PR DESCRIPTION
iOS のターゲットバージョンを 13.0 に上げました。
手元で動作確認をして、iOS で問題なく動作することを確認済みです。