### PR TITLE
マルチ転送フィルターを設定可能にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [CHANGE] forwardingfilters を設定可能にする
+  - マルチ転送フィルターを設定できるように項目を追加
+  - @torikizi
+- [UPDATE] forwardingfilter に name と priority を追加
+  - 既存の forwardingfilter に name と priority を追加
+  - @torikizi
+
 ## sora-unity-sdk-2024.4.0
 
 - [UPDATE] Sora Unity SDK 2024.4.0 にあげる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,6 @@
   - マルチ転送フィルターを設定できるように項目を追加
   - @torikizi
 - [ADD] forwardingfilter に name と priority を追加
-  - 既存の forwardingfilter に name と priority を追加
   - @torikizi
 
 ## sora-unity-sdk-2024.4.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,10 @@
 
 ## develop
 
-- [CHANGE] forwardingfilters を設定可能にする
+- [ADD] forwardingfilters を設定可能にする
   - マルチ転送フィルターを設定できるように項目を追加
   - @torikizi
-- [UPDATE] forwardingfilter に name と priority を追加
+- [ADD] forwardingfilter に name と priority を追加
   - 既存の forwardingfilter に name と priority を追加
   - @torikizi
 

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -132,7 +132,7 @@ public class SoraSample : MonoBehaviour
         public string name;
         public bool enablePriority = false;
         public int priority;
-        public RuleList[] rules;
+        public RuleList[] ruleLists;
         public bool enableVersion = false;
         public string version = "";
         public bool enableMetadata = false;
@@ -152,7 +152,7 @@ public class SoraSample : MonoBehaviour
         if (forwardingFilter.enableName) filter.Name = forwardingFilter.name;
         if (forwardingFilter.enablePriority) filter.Priority = forwardingFilter.priority;
 
-        foreach (var ruleListData in forwardingFilter.rules)
+        foreach (var ruleListData in forwardingFilter.ruleLists)
         {
             var ruleList = new List<Sora.ForwardingFilter.Rule>();
             foreach (var rule in ruleListData.data)
@@ -165,18 +165,11 @@ public class SoraSample : MonoBehaviour
                 newRule.Values.AddRange(rule.values);
                 ruleList.Add(newRule);
             }
-
-            if (ruleList.Any())
-            {
-                filter.Rules.Add(ruleList);
-            }
+            filter.Rules.Add(ruleList);
         }
 
         if (forwardingFilter.enableVersion) filter.Version = forwardingFilter.version;
-        if (forwardingFilter.enableMetadata)
-        {
-            filter.Metadata = JsonUtility.ToJson(forwardingFilter.metadata);
-        }
+        if (forwardingFilter.enableMetadata) filter.Metadata = JsonUtility.ToJson(forwardingFilter.metadata);
 
         return filter;
     }

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -816,7 +816,7 @@ public class SoraSample : MonoBehaviour
             }
             fixedDataChannelLabels = config.DataChannels.Select(x => x.Label).ToArray();
         }
-        if (forwardingFilter.Length != 0)
+        if (forwardingFilter != null && forwardingFilter.Length != 0)
         {
             config.ForwardingFilter = new Sora.ForwardingFilter();
             if (enableForwardingFilterAction) config.ForwardingFilter.Action = forwardingFilterAction;
@@ -830,6 +830,7 @@ public class SoraSample : MonoBehaviour
                     var ccr = new Sora.ForwardingFilter.Rule();
                     ccr.Field = r.field;
                     ccr.Operator = r.op;
+                    ccr.Values = new List<string>();
                     foreach (var v in r.values)
                     {
                         ccr.Values.Add(v);
@@ -845,7 +846,7 @@ public class SoraSample : MonoBehaviour
             forwardingFilters.filters != null &&
             forwardingFilters.filters.Length > 0)
         {
-            config.ForwardingFilters = new Sora.ForwardingFilters();
+            config.ForwardingFilters = new List<Sora.ForwardingFilter>();
 
             foreach (var filter in forwardingFilters.filters)
             {
@@ -910,7 +911,7 @@ public class SoraSample : MonoBehaviour
                     newFilter.Version != null ||
                     newFilter.Metadata != null)
                 {
-                    config.ForwardingFilters.Filters.Add(newFilter);
+                    config.ForwardingFilters.Add(newFilter);
                 }
             }
         }

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -144,7 +144,7 @@ public class SoraSample : MonoBehaviour
     {
         public string metadata;
     }
-    public static Sora.ForwardingFilter ConvertForwardingFilter(ForwardingFilter forwardingFilter)
+    public static Sora.ForwardingFilter ConvertToSoraForwardingFilter(ForwardingFilter forwardingFilter)
     {
         var filter = new Sora.ForwardingFilter();
 
@@ -152,26 +152,23 @@ public class SoraSample : MonoBehaviour
         if (forwardingFilter.enableName) filter.Name = forwardingFilter.name;
         if (forwardingFilter.enablePriority) filter.Priority = forwardingFilter.priority;
 
-        if (forwardingFilter.rules != null)
+        foreach (var ruleListData in forwardingFilter.rules)
         {
-            foreach (var ruleListData in forwardingFilter.rules)
+            var ruleList = new List<Sora.ForwardingFilter.Rule>();
+            foreach (var rule in ruleListData.data)
             {
-                var ruleList = new List<Sora.ForwardingFilter.Rule>();
-                foreach (var rule in ruleListData.data)
+                var newRule = new Sora.ForwardingFilter.Rule
                 {
-                    var newRule = new Sora.ForwardingFilter.Rule
-                    {
-                        Field = rule.field,
-                        Operator = rule.op
-                    };
-                    newRule.Values.AddRange(rule.values);
-                    ruleList.Add(newRule);
-                }
+                    Field = rule.field,
+                    Operator = rule.op
+                };
+                newRule.Values.AddRange(rule.values);
+                ruleList.Add(newRule);
+            }
 
-                if (ruleList.Any())
-                {
-                    filter.Rules.Add(ruleList);
-                }
+            if (ruleList.Any())
+            {
+                filter.Rules.Add(ruleList);
             }
         }
 
@@ -187,6 +184,7 @@ public class SoraSample : MonoBehaviour
     [Header("ForwardingFilter の設定")]
     [System.Obsolete("forwardingFilter は非推奨です。代わりに forwardingFilters を使用してください。")]
     public bool enableForwardingFilter = false;
+    [System.Obsolete("forwardingFilter は非推奨です。代わりに forwardingFilters を使用してください。")]
     public ForwardingFilter forwardingFilter;
 
     [Header("ForwardingFilters の設定")]
@@ -823,7 +821,7 @@ public class SoraSample : MonoBehaviour
         }
         if (enableForwardingFilter)
         {
-            config.ForwardingFilter = ConvertForwardingFilter(forwardingFilter);
+            config.ForwardingFilter = ConvertToSoraForwardingFilter(forwardingFilter);
         }
         if (enableForwardingFilters)
         {
@@ -831,11 +829,8 @@ public class SoraSample : MonoBehaviour
 
             foreach (var filter in forwardingFilters)
             {
-                var newFilter = ConvertForwardingFilter(filter);
-                if (newFilter != null)
-                {
-                    config.ForwardingFilters.Add(newFilter);
-                }
+                var newFilter = ConvertToSoraForwardingFilter(filter);
+                config.ForwardingFilters.Add(newFilter);
             }
         }
         sora.Connect(config);

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -140,6 +140,11 @@ public class SoraSample : MonoBehaviour
     }
     public static class ForwardingFilterHelper
     {
+        [Serializable]
+        private class ForwardingFilterMetadata
+        {
+            public string metadata;
+        }
         private static void ConfigureFilter(Sora.ForwardingFilter filter, ForwardingFilterSettings settings)
         {
             if (settings.enableAction) filter.Action = settings.action;
@@ -177,7 +182,17 @@ public class SoraSample : MonoBehaviour
                 filter.Metadata = ForwardingFilterMetadataHelper.ConvertMetadataToJson(settings.metadata);
             }
         }
-
+        private static class ForwardingFilterMetadataHelper
+        {
+            public static string ConvertMetadataToJson(string metadata)
+            {
+                var ffMetadata = new ForwardingFilterMetadata()
+                {
+                    metadata = metadata
+                };
+                return JsonUtility.ToJson(ffMetadata);
+            }
+        }
         public static Sora.ForwardingFilter CreateFilter(ForwardingFilterSettings settings)
         {
             if (settings == null) return null;
@@ -656,24 +671,6 @@ public class SoraSample : MonoBehaviour
     class VideoH264Params
     {
         public string profile_level_id;
-    }
-
-    [Serializable]
-    class ForwardingFilterMetadata
-    {
-        public string metadata;
-    }
-
-    static class ForwardingFilterMetadataHelper
-    {
-        public static string ConvertMetadataToJson(string metadata)
-        {
-            var ffMetadata = new ForwardingFilterMetadata()
-            {
-                metadata = metadata
-            };
-            return JsonUtility.ToJson(ffMetadata);
-        }
     }
 
     public void OnClickStart()

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -137,40 +137,20 @@ public class SoraSample : MonoBehaviour
     public bool enableForwardingFilterMetadata = false;
     public string forwardingFilterMetadataMessage = "";
 
-
-    [System.Serializable]
-    public class ForwardingFiltersRule
-    {
-        public string field;
-        public string op;
-        public string[] values;
-    }
-    [System.Serializable]
-    public class ForwardingFiltersRuleList
-    {
-        public ForwardingFiltersRule[] data;
-    }
-
     [System.Serializable]
     public class ForwardingFiltersItem
     {
         public string action;
         public string name;
         public int priority;
-        public ForwardingFiltersRuleList[] rules;
+        public RuleList[] rules;
         public string version;
         public string metadata;
     }
 
-    [System.Serializable]
-    public class ForwardingFiltersList
-    {
-        public ForwardingFiltersItem[] filters;
-    }
-
     [Header("ForwardingFilters の設定")]
 
-    public ForwardingFiltersList forwardingFilters;
+    public ForwardingFiltersItem[] forwardingFilters;
 
     [Header("DataChannel シグナリングの設定")]
     public bool dataChannelSignaling = false;
@@ -842,13 +822,11 @@ public class SoraSample : MonoBehaviour
             if (enableForwardingFilterVersion) config.ForwardingFilter.Version = forwardingFilterVersion;
             if (enableForwardingFilterMetadata) config.ForwardingFilter.Metadata = forwardingFilterMetadataJson;
         }
-        if (forwardingFilters != null &&
-            forwardingFilters.filters != null &&
-            forwardingFilters.filters.Length > 0)
+        if (forwardingFilters != null)
         {
             config.ForwardingFilters = new List<Sora.ForwardingFilter>();
 
-            foreach (var filter in forwardingFilters.filters)
+            foreach (var filter in forwardingFilters)
             {
                 var newFilter = new Sora.ForwardingFilter();
 
@@ -895,13 +873,14 @@ public class SoraSample : MonoBehaviour
                     }
                 }
 
-                if (!string.IsNullOrEmpty(filter.version))
-                {
-                    newFilter.Version = filter.version;
-                }
+                newFilter.Version = filter.version;
                 if (!string.IsNullOrEmpty(filter.metadata))
                 {
-                    newFilter.Metadata = filter.metadata;
+                    var ffm = new ForwardingFilterMetadata()
+                    {
+                        forwarding_filter_metadata = filter.metadata
+                    };
+                    newFilter.Metadata = JsonUtility.ToJson(ffm);
                 }
 
                 if (newFilter.Action != null ||

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -124,7 +124,7 @@ public class SoraSample : MonoBehaviour
         public Rule[] data;
     }
     [System.Serializable]
-    public class ForwardingFilterSettings
+    public class ForwardingFilter
     {
         public bool enableAction = false;
         public string action;
@@ -145,7 +145,7 @@ public class SoraSample : MonoBehaviour
         {
             public string metadata;
         }
-        private static void ConfigureFilter(Sora.ForwardingFilter filter, ForwardingFilterSettings settings)
+        private static void ConfigureFilter(Sora.ForwardingFilter filter, ForwardingFilter settings)
         {
             if (settings.enableAction) filter.Action = settings.action;
             if (settings.enableName) filter.Name = settings.name;
@@ -193,7 +193,7 @@ public class SoraSample : MonoBehaviour
                 return JsonUtility.ToJson(ffMetadata);
             }
         }
-        public static Sora.ForwardingFilter CreateFilter(ForwardingFilterSettings settings)
+        public static Sora.ForwardingFilter CreateFilter(ForwardingFilter settings)
         {
             if (settings == null) return null;
 
@@ -205,10 +205,10 @@ public class SoraSample : MonoBehaviour
 
     [Header("ForwardingFilter の設定")]
     [System.Obsolete("forwardingFilter は非推奨です。代わりに forwardingFilters を使用してください。")]
-    public ForwardingFilterSettings forwardingFilter;
+    public ForwardingFilter forwardingFilter;
 
     [Header("ForwardingFilters の設定")]
-    public ForwardingFilterSettings[] forwardingFilters;
+    public ForwardingFilter[] forwardingFilters;
 
     [Header("DataChannel シグナリングの設定")]
     public bool dataChannelSignaling = false;

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -615,6 +615,18 @@ public class SoraSample : MonoBehaviour
         public string metadata;
     }
 
+    static class ForwardingFilterMetadataHelper
+    {
+        public static string ConvertMetadataToJson(string metadata)
+        {
+            var ffMetadata = new ForwardingFilterMetadata()
+            {
+                metadata = metadata
+            };
+            return JsonUtility.ToJson(ffMetadata);
+        }
+    }
+
     public void OnClickStart()
     {
 
@@ -688,16 +700,6 @@ public class SoraSample : MonoBehaviour
                 profile_level_id = videoH264ParamsProfileLevelId
             };
             videoH264ParamsJson = JsonUtility.ToJson(h264Params);
-        }
-        // enableForwardingFilterMetadata が true の場合はメタデータを設定する
-        string forwardingFilterMetadataJson = "";
-        if (forwardingFilterSettings.enableMetadata)
-        {
-            var ffMetadata = new ForwardingFilterMetadata()
-            {
-                metadata = forwardingFilterSettings.metadata
-            };
-            forwardingFilterMetadataJson = JsonUtility.ToJson(ffMetadata);
         }
 
         InitSora();
@@ -819,7 +821,10 @@ public class SoraSample : MonoBehaviour
             }
 
             if (forwardingFilterSettings.enableVersion) config.ForwardingFilter.Version = forwardingFilterSettings.version;
-            if (forwardingFilterSettings.enableMetadata) config.ForwardingFilter.Metadata = forwardingFilterMetadataJson;
+            if (forwardingFilterSettings.enableMetadata)
+            {
+                config.ForwardingFilter.Metadata = ForwardingFilterMetadataHelper.ConvertMetadataToJson(forwardingFilterSettings.metadata);
+            }
         }
 
         if (forwardingFilters != null && forwardingFilters.Length > 0)
@@ -860,13 +865,8 @@ public class SoraSample : MonoBehaviour
                 if (filter.enableVersion) newFilter.Version = filter.version;
                 if (filter.enableMetadata)
                 {
-                    var ffMetadata = new ForwardingFilterMetadata()
-                    {
-                        metadata = filter.metadata
-                    };
-                    newFilter.Metadata = JsonUtility.ToJson(ffMetadata);
+                    newFilter.Metadata = ForwardingFilterMetadataHelper.ConvertMetadataToJson(filter.metadata);
                 }
-
                 config.ForwardingFilters.Add(newFilter);
             }
         }

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -835,12 +835,9 @@ public class SoraSample : MonoBehaviour
             {
                 var newFilter = new Sora.ForwardingFilter();
 
-                if (filter.enableAction)
-                    newFilter.Action = filter.action;
-                if (filter.enableName)
-                    newFilter.Name = filter.name;
-                if (filter.enablePriority)
-                    newFilter.Priority = filter.priority;
+                if (filter.enableAction) newFilter.Action = filter.action;
+                if (filter.enableName) newFilter.Name = filter.name;
+                if (filter.enablePriority) newFilter.Priority = filter.priority;
 
                 if (filter.rules == null) return;
 

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -136,7 +136,7 @@ public class SoraSample : MonoBehaviour
         public bool enableVersion = false;
         public string version = "";
         public bool enableMetadata = false;
-        public ForwardingFilterMetadata metadata = new ForwardingFilterMetadata();
+        public ForwardingFilterMetadata metadata;
     }
 
     [Serializable]

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -136,11 +136,11 @@ public class SoraSample : MonoBehaviour
         public bool enableVersion = false;
         public string version = "";
         public bool enableMetadata = false;
-        public string metadata = "";
+        public ForwardingFilterMetadata metadata = new ForwardingFilterMetadata();
     }
 
     [Serializable]
-    private class ForwardingFilterMetadata
+    public class ForwardingFilterMetadata
     {
         public string metadata;
     }
@@ -178,10 +178,7 @@ public class SoraSample : MonoBehaviour
         if (forwardingFilter.enableVersion) filter.Version = forwardingFilter.version;
         if (forwardingFilter.enableMetadata)
         {
-            filter.Metadata = JsonUtility.ToJson(new ForwardingFilterMetadata()
-            {
-                metadata = forwardingFilter.metadata
-            });
+            filter.Metadata = JsonUtility.ToJson(forwardingFilter.metadata);
         }
 
         return filter;

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -204,7 +204,8 @@ public class SoraSample : MonoBehaviour
     }
 
     [Header("ForwardingFilter の設定")]
-    public ForwardingFilterSettings forwardingFilterSettings;
+    [System.Obsolete("forwardingFilter は非推奨です。代わりに forwardingFilters を使用してください。")]
+    public ForwardingFilterSettings forwardingFilter;
 
     [Header("ForwardingFilters の設定")]
     public ForwardingFilterSettings[] forwardingFilters;
@@ -837,9 +838,9 @@ public class SoraSample : MonoBehaviour
             }
             fixedDataChannelLabels = config.DataChannels.Select(x => x.Label).ToArray();
         }
-        if (forwardingFilterSettings != null)
+        if (forwardingFilter != null)
         {
-            config.ForwardingFilter = ForwardingFilterHelper.CreateFilter(forwardingFilterSettings);
+            config.ForwardingFilter = ForwardingFilterHelper.CreateFilter(forwardingFilter);
         }
         if (forwardingFilters != null && forwardingFilters.Length > 0)
         {


### PR DESCRIPTION
- ForwardingFilter に name と priority を追加
- forwardingfilters を設定できるよう追加

---
This pull request introduces new functionality for configuring forwarding filters, including adding names and priorities, and deprecates the old forwarding filter method. Additionally, it updates the `SoraSample.cs` file to reflect these changes.

### New Features:
* Added the ability to configure multiple forwarding filters with new attributes such as `name` and `priority`. (`CHANGES.md`, [SoraUnitySdkSamples/Assets/SoraSample.csR126-R194](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bR126-R194))

### Code Updates:
* Introduced a new `ForwardingFilter` class with attributes and a `ConvertForwardingFilter` method to handle the conversion of these filters. (`SoraUnitySdkSamples/Assets/SoraSample.cs`, [SoraUnitySdkSamples/Assets/SoraSample.csR126-R194](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bR126-R194))
* Deprecated the old forwarding filter configuration in favor of the new multiple forwarding filters configuration. (`SoraUnitySdkSamples/Assets/SoraSample.cs`, [[1]](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bR126-R194) [[2]](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bL780-L803)
* Removed the old `ForwardingFilterMetadata` class and its usage from the `OnClickStart` method. (`SoraUnitySdkSamples/Assets/SoraSample.cs`, [[1]](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bL600-L605) [[2]](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bL680-L689)