### PR TITLE
DataChannel に Header を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
   - @torikizi
 - [ADD] forwardingfilter に name と priority を追加
   - @torikizi
+- [ADD] datachannel に header を追加
+  - @torikizi
 
 ## sora-unity-sdk-2024.4.0
 

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -205,6 +205,9 @@ public class SoraSample : MonoBehaviour
         public string protocol;
         public bool enableCompress;
         public bool compress;
+        public bool enableHeader;
+        public List<string> Header { get; set; } = new List<string> { "{\"type\": \"sender_connection_id\"}" };
+
     }
 
     [Header("DataChannel メッセージングの設定")]
@@ -808,6 +811,10 @@ public class SoraSample : MonoBehaviour
                 if (m.enableMaxRetransmits) c.MaxRetransmits = m.maxRetransmits;
                 if (m.enableProtocol) c.Protocol = m.protocol;
                 if (m.enableCompress) c.Compress = m.compress;
+                if (m.enableHeader && m.direction != Sora.Direction.Sendonly)
+                {
+                    c.Header = m.Header;
+                }
                 config.DataChannels.Add(c);
             }
             fixedDataChannelLabels = config.DataChannels.Select(x => x.Label).ToArray();

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -206,8 +206,7 @@ public class SoraSample : MonoBehaviour
         public bool enableCompress;
         public bool compress;
         public bool enableHeader;
-        public List<string> Header { get; set; } = new List<string> { "{\"type\": \"sender_connection_id\"}" };
-
+        public string[] header;
     }
 
     [Header("DataChannel メッセージングの設定")]
@@ -811,10 +810,7 @@ public class SoraSample : MonoBehaviour
                 if (m.enableMaxRetransmits) c.MaxRetransmits = m.maxRetransmits;
                 if (m.enableProtocol) c.Protocol = m.protocol;
                 if (m.enableCompress) c.Compress = m.compress;
-                if (m.enableHeader && m.direction != Sora.Direction.Sendonly)
-                {
-                    c.Header = m.Header;
-                }
+                if (m.enableHeader) c.Header = m.header.ToList();
                 config.DataChannels.Add(c);
             }
             fixedDataChannelLabels = config.DataChannels.Select(x => x.Label).ToArray();


### PR DESCRIPTION
DataChannel に Header を追加。
Header の設定は Enable フラグで行い、固定値をセットする

----
This pull request includes updates to the `SoraUnitySdkSamples` to add header functionality to the `DataChannel` class, as well as an update to the `CHANGES.md` file to document this new feature.

### New Feature Addition:

* [`SoraUnitySdkSamples/Assets/SoraSample.cs`](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bR208-R210): Added `enableHeader` and `Header` properties to the `DataChannel` class to support headers in data channels.
* [`SoraUnitySdkSamples/Assets/SoraSample.cs`](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bR814-R817): Updated the `OnClickStart` method to set the `Header` property when `enableHeader` is true and the direction is not `Sendonly`.

### Documentation Update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R18-R19): Documented the addition of the `header` property to the `datachannel`.