### PR TITLE
SORA_UNITY_SDK_VERSION を 2025.2.0-canary.2 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
 
 - [CHANGE] Editor のバージョンを 6000.0.38f1 にあげる
   - @miosakuma
+- [CHANGE] useHardwareEncoder の設定を削除する
+  - @torikizi
 
 ## sora-unity-sdk-2025.1.0
 

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -69,7 +69,6 @@ public class SoraSample : MonoBehaviour
     public bool noVideoDevice = false;
     public new bool audio = true;
     public bool noAudioDevice = false;
-    public bool useHardwareEncoder = true;
     public Sora.VideoCodecType videoCodecType = Sora.VideoCodecType.VP9;
     public bool enableVideoVp9Params = false;
     public int videoVp9ParamsProfileId;
@@ -747,7 +746,6 @@ public class SoraSample : MonoBehaviour
             NoVideoDevice = noVideoDevice,
             Audio = audio,
             NoAudioDevice = noAudioDevice,
-            UseHardwareEncoder = useHardwareEncoder,
             VideoCodecType = videoCodecType,
             VideoVp9Params = videoVp9ParamsJson,
             VideoAv1Params = videoAv1ParamsJson,

--- a/install.py
+++ b/install.py
@@ -12,7 +12,7 @@ from typing import Optional
 logging.basicConfig(level=logging.DEBUG)
 
 
-SORA_UNITY_SDK_VERSION = "2025.2.0-canary.0"
+SORA_UNITY_SDK_VERSION = "2025.2.0-canary.2"
 
 
 class ChangeDirectory(object):


### PR DESCRIPTION
Sora Unity SDK のアップデートとアップデートに伴い useHardwareEncoder の設定を削除しました