### PR TITLE
VideoCodecPreference を追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,9 +17,14 @@
   - @miosakuma
 - [CHANGE] useHardwareEncoder の設定を削除する
   - @torikizi
-- [CHANGE] `SoraSample.cs` に `VideoCodecPreference` を追加
-  - 従来通りハードウェアエンコーダーを自動で優先的に使用する
-  - 優先順位は `Intel VPL` -> `AMD AMF` -> `Nvidia Video Codec SDK` -> `Internal` の順番で優先される
+- [CHANGE] SoraSample.cs に `VideoCodecPreference` の設定を追加
+  - 従来通り、使用可能なハードウェアエンコーダーを自動で優先的に使用する挙動を維持する
+  - `Sora.GetVideoCodecCapability()` で取得したコーデック情報をもとに、`Sora.VideoCodecPreference.GetHardwareEncoderPreference()` を使用して優先順位付きリストを生成する
+    - 次の順序で優先する(上から優先する)
+      - Intel VPL
+      - AMD AMF
+      - NVIDIA Video Codec SDK
+      - Internal
   - @torikizi
 - [ADD] enableVideoCodecType チェックボックスを追加
   - @miosakuma

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@
   - @miosakuma
 - [CHANGE] useHardwareEncoder の設定を削除する
   - @torikizi
+- [CHANGE] `SoraSample.cs` に `VideoCodecPreference` を追加
+  - 従来通りハードウェアエンコーダーを自動で優先的に使用する
+  - 優先順位は `Intel VPL` -> `AMD AMF` -> `Nvidia Video Codec SDK` -> `Internal` の順番で優先される
+  - @torikizi
 
 ### misc
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,20 +11,20 @@
 
 ## develop
 
-- [CHANGE] Sora Unity SDK のバージョンを 2025.2.0-canary.1 にあげる
-  - @miosakuma
-- [CHANGE] Editor のバージョンを 6000.0.38f1 にあげる
-  - @miosakuma
 - [CHANGE] useHardwareEncoder の設定を削除する
   - @torikizi
-- [UPDATE] SoraSample.cs に `VideoCodecPreference` の設定を追加
-  - 従来通り、使用可能なハードウェアエンコーダーを自動で優先的に使用する挙動を維持する
-  - `Sora.GetVideoCodecCapability()` で取得したコーデック情報をもとに、`Sora.VideoCodecPreference.GetHardwareAcceleratorPreference()` を使用して利用するエンコーダーとデコーダーを指定する
-  - @torikizi
+- [UPDATE] Sora Unity SDK のバージョンを 2025.2.0-canary.1 にあげる
+  - @miosakuma
+- [UPDATE] Editor のバージョンを 6000.0.38f1 にあげる
+  - @miosakuma
 - [ADD] enableVideoCodecType チェックボックスを追加
   - @miosakuma
 - [ADD] enableAudioCodecType チェックボックスを追加
   - @miosakuma
+- [ADD] SoraSample.cs に `VideoCodecPreference` の設定を追加
+  - 従来通り、使用可能なハードウェアエンコーダーを自動で優先的に使用する挙動を維持する
+  - `Sora.GetVideoCodecCapability()` で取得したコーデック情報をもとに、`Sora.VideoCodecPreference.GetHardwareAcceleratorPreference()` を使用して利用するエンコーダーとデコーダーを指定する
+  - @torikizi
 
 ### misc
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@
   - @torikizi
 - [UPDATE] SoraSample.cs に `VideoCodecPreference` の設定を追加
   - 従来通り、使用可能なハードウェアエンコーダーを自動で優先的に使用する挙動を維持する
-  - `Sora.GetVideoCodecCapability()` で取得したコーデック情報をもとに、`Sora.VideoCodecPreference.GetHardwareEncoderPreference()` を使用して利用するエンコーダーとデコーダーを生成する
+  - `Sora.GetVideoCodecCapability()` で取得したコーデック情報をもとに、`Sora.VideoCodecPreference.GetHardwareAcceleratorPreference()` を使用して利用するエンコーダーとデコーダーを指定する
   - @torikizi
 - [ADD] enableVideoCodecType チェックボックスを追加
   - @miosakuma

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,14 +17,9 @@
   - @miosakuma
 - [CHANGE] useHardwareEncoder の設定を削除する
   - @torikizi
-- [CHANGE] SoraSample.cs に `VideoCodecPreference` の設定を追加
+- [UPDATE] SoraSample.cs に `VideoCodecPreference` の設定を追加
   - 従来通り、使用可能なハードウェアエンコーダーを自動で優先的に使用する挙動を維持する
-  - `Sora.GetVideoCodecCapability()` で取得したコーデック情報をもとに、`Sora.VideoCodecPreference.GetHardwareEncoderPreference()` を使用して優先順位付きリストを生成する
-    - 次の順序で優先する(上から優先する)
-      - Intel VPL
-      - AMD AMF
-      - NVIDIA Video Codec SDK
-      - Internal
+  - `Sora.GetVideoCodecCapability()` で取得したコーデック情報をもとに、`Sora.VideoCodecPreference.GetHardwareEncoderPreference()` を使用して利用するエンコーダーとデコーダーを生成する
   - @torikizi
 - [ADD] enableVideoCodecType チェックボックスを追加
   - @miosakuma

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -786,7 +786,7 @@ public class SoraSample : MonoBehaviour
         };
         // ハードウェアエンコーダーが使える場合は優先して使う
         var capability = Sora.GetVideoCodecCapability(new Sora.VideoCodecCapabilityConfig());
-        var preference = Sora.VideoCodecPreference.GetHardwareEncoderPreference(capability);
+        var preference = Sora.VideoCodecPreference.GetHardwareAcceleratorPreference(capability);
         config.VideoCodecPreference = preference;
         if (enableVideoCodecType)
         {

--- a/SoraUnitySdkSamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkSamples/Assets/SoraSample.cs
@@ -784,6 +784,10 @@ public class SoraSample : MonoBehaviour
             ProxyUsername = proxyUsername,
             ProxyPassword = proxyPassword,
         };
+        // ハードウェアエンコーダーが使える場合は優先して使う
+        var capability = Sora.GetVideoCodecCapability(new Sora.VideoCodecCapabilityConfig());
+        var preference = Sora.VideoCodecPreference.GetHardwareEncoderPreference(capability);
+        config.VideoCodecPreference = preference;
         if (enableSpotlightFocusRid)
         {
             config.SpotlightFocusRid = spotlightFocusRid;


### PR DESCRIPTION
これまで通り、自動で HWA が設定されるように、VideoCodecPreference を追加して HWA を利用可能にします。

----
This pull request includes changes to enhance the video codec preference functionality in the `SoraSample.cs` file and updates the change log accordingly. The most important changes include adding the `VideoCodecPreference` to prioritize hardware encoders and updating the `CHANGES.md` file to reflect this addition.

Enhancements to video codec preference functionality:

* [`SoraUnitySdkSamples/Assets/SoraSample.cs`](diffhunk://#diff-12695070cb2312ef563a9b63cc33a776880479ed95398221170c3c4e3876858bR787-R790): Added logic to prioritize hardware encoders using `VideoCodecPreference` in the `OnClickStart` method.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R18-R21): Updated to include the addition of `VideoCodecPreference` in `SoraSample.cs` and its prioritization order.