### PR TITLE
libSoraUnitySdk.so.meta を更新

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@
 
 - [UPDATE] SoraSample.cs の改行コードを LF に統一する
   - @torikizi
+- [UPDATE] Plugins/SoraUnitySDK/android/arm64-v8a/libSoraUnitySdk.so.meta を更新
+  - 16KB 対応した libSoraUnitySdk.so の設定を反映するため
+  - @torikizi
 - [ADD] .github ディレクトリと copilot-instructions.md を追加
   - @torikizi
 

--- a/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/android/arm64-v8a/libSoraUnitySdk.so.meta
+++ b/SoraUnitySdkSamples/Assets/Plugins/SoraUnitySdk/android/arm64-v8a/libSoraUnitySdk.so.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: b86bffc43f1bc4e85a95745780e4af86
+guid: 95d973b6d05b2ca4dbf4a5bbd2398426
 PluginImporter:
   externalObjects: {}
-  serializedVersion: 2
+  serializedVersion: 3
   iconMap: {}
   executionOrder: {}
   defineConstraints: []
@@ -11,9 +11,14 @@ PluginImporter:
   isExplicitlyReferenced: 0
   validateReferences: 1
   platformData:
-  - first:
-      : Any
-    second:
+    Android:
+      enabled: 1
+      settings:
+        AndroidLibraryDependee: UnityLibrary
+        AndroidSharedLibraryType: Executable
+        CPU: ARM64
+        Is16KbAligned: true
+    Any:
       enabled: 0
       settings:
         Exclude Android: 0


### PR DESCRIPTION
16KB 対応を反映させるため metadata を作り直しました。